### PR TITLE
input refactor

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -38,6 +38,19 @@ jobs:
           path: dist/
           retention-days: 30
 
+  unit-test:
+    name: Run unit tests
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v4
+        with:
+          python-version: "3.10"
+          cache: "pip"
+      - run: pip install .[test]
+      - run: pytest test/
+
   publish-to-pypi:
     name: Publish to PyPI
     runs-on: ubuntu-latest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,9 @@ dependencies = [
 ui = [
   "fastapi[standard]"
 ]
+test = [
+    "pytest"
+]
 
 [project.scripts]
 package-skill = "skill_framework.package:package_skill"

--- a/readme.md
+++ b/readme.md
@@ -34,7 +34,8 @@ If you already have one, this script will not replace it.
 A skill needs to have a `@skill` decorated entry point, like this:
 
 ```python
-from skill_framework import skill, SkillParameters, SkillParameter, SkillOutput
+from skill_framework import skill, SkillInput, SkillParameter, SkillOutput
+
 
 @skill(
     name="my_skill",
@@ -46,7 +47,7 @@ from skill_framework import skill, SkillParameters, SkillParameter, SkillOutput
         )
     ]
 )
-def my_skill(parameters: SkillParameters):
+def my_skill(parameters: SkillInput):
     # you can access arguments to your parameters extracted from
     # natural language queries via the arguments field
     # other run-specific context will also be provided on this object
@@ -57,22 +58,26 @@ def my_skill(parameters: SkillParameters):
     narrative = create_narrative(data)
     prompt = create_chat_response_prompt(data, narrative)
     return SkillOutput(
-      final_prompt=prompt,
-      narrative=narrative,
-      visualization=visualization
+        final_prompt=prompt,
+        narrative=narrative,
+        visualization=visualization
     )
+
 
 def get_some_data(params):
     # use the client to get some data from a dataset
     pass
 
+
 def create_visualization(data):
     # embed the data into a json layout payload
     pass
 
+
 def create_narrative(data):
     # make some description of the data to appear as the narrative part of the response
     pass
+
 
 def create_chat_response_prompt(data, narrative):
     # use the data and narrative to create a prompt for the model that will generate the response
@@ -83,11 +88,10 @@ def create_chat_response_prompt(data, narrative):
 You can generate a preview for viewing with the `preview-server` by passing your skill's output to `preview_skill`:
 
 ```python
-from skill_framework import SkillParameters, preview_skill
-
+from skill_framework import SkillInput, preview_skill
 
 if __name__ == '__main__':
-    mock_params = SkillParameters(
+    mock_params = SkillInput(
         # mock values here
     )
     output = your_skill(mock_params)

--- a/skill_framework/__init__.py
+++ b/skill_framework/__init__.py
@@ -1,12 +1,12 @@
 __all__ = [
     'skill',
-    'SkillParameters',
+    'SkillInput',
     'SkillParameter',
     'preview_skill',
     'SkillOutput',
 ]
 
-from skill_framework.skills import skill, SkillParameters, SkillParameter, SkillOutput
+from skill_framework.skills import skill, SkillInput, SkillParameter, SkillOutput
 from skill_framework.preview import preview_skill
 
 __version__ = '0.1.0'

--- a/skill_framework/skills.py
+++ b/skill_framework/skills.py
@@ -94,11 +94,11 @@ class Skill:
     def create_input(self, assistant_id=None, arguments: dict | None = None) -> SkillInput:
         if not arguments:
             arguments = {}
-        skill_arguments = _create_skill_arguments(self, **arguments)
+        skill_arguments = _create_skill_arguments(self, arguments)
         return SkillInput(assistant_id=assistant_id, arguments=skill_arguments)
 
 
-def _create_skill_arguments(skill: Skill, **kwargs):
+def _create_skill_arguments(skill: Skill, arguments):
     def field_type(p: SkillParameter):
         return list[str] if p.is_multi else str | None
 
@@ -113,7 +113,11 @@ def _create_skill_arguments(skill: Skill, **kwargs):
         'SkillArguments',
         fields,
     )
-    return cls(**kwargs)
+    valid_parameter_names = [param.name for param in skill.parameters]
+    assign_args = {
+        k: v for k, v in arguments.items() if k in valid_parameter_names
+    }
+    return cls(**assign_args)
 
 
 class Node:

--- a/skill_framework/skills.py
+++ b/skill_framework/skills.py
@@ -1,9 +1,10 @@
 import inspect
 import jinja2
+import keyword
 import os
-from pydantic import BaseModel, ConfigDict
-from types import SimpleNamespace
-from typing import Callable
+from dataclasses import make_dataclass, field
+from pydantic import BaseModel, ConfigDict, field_validator
+from typing import Callable, Literal
 from skill_framework.util import flexible_decorator
 
 
@@ -12,15 +13,49 @@ class FrameworkBaseModel(BaseModel):
 
 
 class SkillParameter(FrameworkBaseModel):
+    """
+    Used in the @skill decorator to define parameters for your skill.
+    Attributes:
+        name: the name of the parameter. this needs to be a valid python identifier, as these names are used to generate
+            a dataclass that will contain the parameter arguments when your skill is invoked.
+        constrained_to: limit the valid arguments to this parameter to a particular type
+        is_multi: if true, multiple arguments can be assigned to this parameter, and its value will always be a list
+        description: the parameter description that will appear in the UI
+        constrained_values: if set, limits the valid arguments to this parameter to those in this list
+    """
     name: str
-    constrained_to: str | None = None
+    constrained_to: Literal['metrics', 'dimensions', 'filters'] | None = None
     is_multi: bool = False
+    description: str | None = None
+    constrained_values: list[str] = field(default_factory=list)
+
+    @field_validator('name')
+    @classmethod
+    def validate_name(cls, v):
+        if not is_valid_parameter_name(v):
+            raise ValueError('Parameter name must be a valid python identifier')
+        return v
 
 
-class SkillParameters:
-    def __init__(self, assistant_id, **kwargs):
+def is_valid_parameter_name(name: str) -> bool:
+    return name.isidentifier() and not keyword.iskeyword(name)
+
+
+class SkillInput:
+    """
+    Container for context and parameter arguments passed into the skill. Recommended to create this object with
+    the Skill.create_input helper method,
+
+    Attributes:
+        assistant_id: the id of the assistant in which your skill is running
+        arguments: the arguments for your skill's parameters extracted from, for example, a chat interaction. This is a
+            generated dataclass at runtime, so you can use attribute-style access to refer to them. "empty" values will
+            be populated based on your declared parameters. f. ex, a list parameter for which no arguments were captured
+            will be initialized to an empty list.
+    """
+    def __init__(self, assistant_id, arguments):
         self.assistant_id = assistant_id
-        self.arguments = SimpleNamespace(**kwargs)
+        self.arguments = arguments
 
     def __str__(self):
         return str(self.__dict__)
@@ -41,9 +76,9 @@ class SkillOutput(FrameworkBaseModel):
 
 
 class Skill:
-    def __init__(self, fn: Callable[[SkillParameters], SkillOutput], name=None, description=None, parameters=None):
+    def __init__(self, fn: Callable[[SkillInput], SkillOutput], name=None, description=None, parameters=None):
         self.fn = fn
-        self.parameters = parameters or []
+        self.parameters: list[SkillParameter] = parameters or []
         self.name = name or fn.__name__
         self.description = description
         self.nodes = []
@@ -55,6 +90,30 @@ class Skill:
         n = Node(fn, skill=self)
         self.nodes.append(n)
         return n
+
+    def create_input(self, assistant_id=None, arguments: dict | None = None) -> SkillInput:
+        if not arguments:
+            arguments = {}
+        skill_arguments = _create_skill_arguments(self, **arguments)
+        return SkillInput(assistant_id=assistant_id, arguments=skill_arguments)
+
+
+def _create_skill_arguments(skill: Skill, **kwargs):
+    def field_type(p: SkillParameter):
+        return list[str] if p.is_multi else str | None
+
+    def parameter_field(p: SkillParameter):
+        return field(default_factory=list) if p.is_multi else field(default=None)
+
+    fields = [
+        (param.name, field_type(param), parameter_field(param))
+        for param in skill.parameters
+    ]
+    cls = make_dataclass(
+        'SkillArguments',
+        fields,
+    )
+    return cls(**kwargs)
 
 
 class Node:
@@ -69,9 +128,15 @@ class Node:
 
 
 @flexible_decorator
-def skill(fn: Callable[[SkillParameters], SkillOutput], name: str = None, parameters: list[SkillParameter] | None = None, description: str = None):
+def skill(fn: Callable[[SkillInput], SkillOutput], name: str = None, parameters: list[SkillParameter] | None = None, description: str = None):
     """
-    Marks a function as a skill entrypoint.
+    Marks a function as a skill entry point.
+    :param name: the name of the skill, will default to the function's name if not provided.
+    :param parameters: a list of SkillParameters
+    :param description: the description of the skill that will appear in the ui
+    :return: your skill function wrapped in a Skill class that wraps the metadata defined in the constructor and
+        provides utility methods. This class defines __call__, so it can still be used like a normal function for the
+        purposes of testing.
     """
     return Skill(fn, name=name, parameters=parameters, description=description)
 

--- a/skill_framework/skills.py
+++ b/skill_framework/skills.py
@@ -4,7 +4,7 @@ import keyword
 import os
 from dataclasses import make_dataclass, field
 from pydantic import BaseModel, ConfigDict, field_validator
-from typing import Callable, Literal
+from typing import Callable, Literal, Any
 from skill_framework.util import flexible_decorator
 
 
@@ -100,7 +100,7 @@ class Skill:
 
 def _create_skill_arguments(skill: Skill, arguments):
     def field_type(p: SkillParameter):
-        return list[str] if p.is_multi else str | None
+        return list[Any] if p.is_multi else Any | None
 
     def parameter_field(p: SkillParameter):
         return field(default_factory=list) if p.is_multi else field(default=None)

--- a/skill_framework/starter_skill/my_skill.py
+++ b/skill_framework/starter_skill/my_skill.py
@@ -1,4 +1,4 @@
-from skill_framework import skill, SkillParameter, SkillParameters, SkillOutput
+from skill_framework import skill, SkillParameter, SkillInput, SkillOutput
 
 
 @skill(
@@ -11,5 +11,5 @@ from skill_framework import skill, SkillParameter, SkillParameters, SkillOutput
         )
     ]
 )
-def my_skill(parameters: SkillParameters) -> SkillOutput:
+def my_skill(parameters: SkillInput) -> SkillOutput:
     pass

--- a/test/test_input_init.py
+++ b/test/test_input_init.py
@@ -24,3 +24,9 @@ def test_empty_args():
     assert skill_input.arguments.dim is None
 
 
+def test_invalid_arg():
+    skill_input = dummy_skill.create_input(arguments={'metrics': ['sales'], 'bad_arg': 'some value'})
+    assert skill_input.arguments.metrics[0] == 'sales'
+    assert not hasattr(skill_input.arguments, 'bad_arg')
+
+

--- a/test/test_input_init.py
+++ b/test/test_input_init.py
@@ -1,0 +1,26 @@
+from skill_framework import skill, SkillParameter, SkillInput
+
+@skill(
+    name="some_skill",
+    parameters=[
+        SkillParameter(name='metrics', is_multi=True),
+        SkillParameter(name='dim')
+    ]
+)
+def dummy_skill():
+    pass
+
+
+def test_args():
+    skill_input: SkillInput = dummy_skill.create_input(arguments={'metrics': ['sales']})
+    assert skill_input.arguments.metrics[0] == 'sales'
+    assert skill_input.arguments.dim is None
+
+
+def test_empty_args():
+    skill_input = dummy_skill.create_input()
+    assert isinstance(skill_input.arguments.metrics, list)
+    assert len(skill_input.arguments.metrics) == 0
+    assert skill_input.arguments.dim is None
+
+


### PR DESCRIPTION
- Rename SkillParameters to SkillInput so there's less confusion with SkillParameter and it matches up with SkillOutput
- add a helper method for creating SkillInput that uses SkillParameter definitions to generate a dataclass (with defaults) to replace the less than ideal SimpleNamespace setup that was there before.
- add some unit tests and docstrings