### PR TITLE
support for multiple visualizations

### DIFF
--- a/layout-previewer/package-lock.json
+++ b/layout-previewer/package-lock.json
@@ -13,7 +13,8 @@
         "react": "18",
         "react-dom": "18",
         "react-router-dom": "^6.22.3",
-        "react-scripts": "5.0.1"
+        "react-scripts": "5.0.1",
+        "react-tabs": "^6.1.0"
       },
       "devDependencies": {
         "@types/react": "18",
@@ -5219,6 +5220,14 @@
         "string-width": "^4.2.0",
         "strip-ansi": "^6.0.0",
         "wrap-ansi": "^7.0.0"
+      }
+    },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/co": {
@@ -12985,6 +12994,18 @@
         "typescript": {
           "optional": true
         }
+      }
+    },
+    "node_modules/react-tabs": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/react-tabs/-/react-tabs-6.1.0.tgz",
+      "integrity": "sha512-6QtbTRDKM+jA/MZTTefvigNxo0zz+gnBTVFw2CFVvq+f2BuH0nF0vDLNClL045nuTAdOoK/IL1vTP0ZLX0DAyQ==",
+      "dependencies": {
+        "clsx": "^2.0.0",
+        "prop-types": "^15.5.0"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/read-cache": {

--- a/layout-previewer/package.json
+++ b/layout-previewer/package.json
@@ -3,16 +3,17 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
+    "@answerrocket/dynamic-layout": "git+https://bitbucket.org/aglabs/dynamic-layout.git#main",
     "cra-template": "1.2.0",
     "react": "18",
     "react-dom": "18",
     "react-router-dom": "^6.22.3",
     "react-scripts": "5.0.1",
-    "@answerrocket/dynamic-layout": "git+https://bitbucket.org/aglabs/dynamic-layout.git#main"
+    "react-tabs": "^6.1.0"
   },
   "devDependencies": {
-      "@types/react": "18",
-      "@types/react-dom": "18"
+    "@types/react": "18",
+    "@types/react-dom": "18"
   },
   "scripts": {
     "start": "react-scripts start",

--- a/layout-previewer/src/pages/PrintPage.js
+++ b/layout-previewer/src/pages/PrintPage.js
@@ -1,21 +1,23 @@
 import React, { useState, useEffect } from 'react';
 import { useParams } from 'react-router-dom';
 import { DynamicGridLayout } from '@answerrocket/dynamic-layout';
+import { Tab, Tabs, TabList, TabPanel } from 'react-tabs';
+import 'react-tabs/style/react-tabs.css';
 
 const PrintPage = () => {
   const { '*': pageId } = useParams();
-  const [pageDefinition, setPageDefinition] = useState(null);
+  const [visualizations, setVisualizations] = useState(null);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState(null);
 
   useEffect(() => {
-    const loadPageDefinition = async () => {
+    const loadVisualizations = async () => {
       setIsLoading(true);
       setError(null);
       try {
         const res = await fetch(`/previews/${pageId}`)
         const def = await res.json()
-        setPageDefinition(def);
+        setVisualizations(def);
       } catch (error) {
         console.error('Error loading page definition:', error);
         setError(error.message);
@@ -24,7 +26,7 @@ const PrintPage = () => {
       }
     };
 
-    loadPageDefinition();
+    loadVisualizations();
   }, [pageId]);
 
   // Memoize the callbacks to prevent unnecessary re-renders
@@ -33,16 +35,31 @@ const PrintPage = () => {
 
   if (isLoading) return <div>Loading...</div>;
   if (error) return <div>Error: {error}</div>;
-  if (!pageDefinition) return <div>No page definition found</div>;
+  if (!visualizations) return <div>No page definition found</div>;
+
+  const titles = visualizations.map(viz => viz.title)
+  const layouts = visualizations.map(viz => JSON.parse(viz.layout))
 
   return (
     <div className="print-page-container">
-      <DynamicGridLayout 
-        pageDefinition={pageDefinition}
-        onElementSelect={handleElementSelect}
-        onUpdateElement={handleUpdateElement}
-        className="grid-layout-container"
-      />
+      <Tabs>
+        <TabList>
+        {titles.map((title) => 
+          <Tab>{title}</Tab>
+        )}
+        </TabList>
+        {layouts.map((layout) => 
+          <TabPanel>
+            <DynamicGridLayout 
+              pageDefinition={layout}
+              onElementSelect={handleElementSelect}
+              onUpdateElement={handleUpdateElement}
+              className="grid-layout-container"
+            />
+          </TabPanel>
+        )}
+
+      </Tabs>
     </div>
   );
 };

--- a/layout-previewer/src/pages/PrintPage.js
+++ b/layout-previewer/src/pages/PrintPage.js
@@ -38,7 +38,7 @@ const PrintPage = () => {
   if (!visualizations) return <div>No page definition found</div>;
 
   const titles = visualizations.map(viz => viz.title)
-  const layouts = visualizations.map(viz => JSON.parse(viz.layout))
+  const layouts = visualizations.map(viz => viz.layout)
 
   return (
     <div className="print-page-container">

--- a/readme.md
+++ b/readme.md
@@ -34,7 +34,7 @@ If you already have one, this script will not replace it.
 A skill needs to have a `@skill` decorated entry point, like this:
 
 ```python
-from skill_framework import skill, SkillInput, SkillParameter, SkillOutput
+from skill_framework import skill, SkillInput, SkillParameter, SkillOutput, SkillVisualization
 
 
 @skill(
@@ -60,7 +60,7 @@ def my_skill(parameters: SkillInput):
     return SkillOutput(
         final_prompt=prompt,
         narrative=narrative,
-        visualization=visualization
+        visualizations=[visualization],
     )
 
 
@@ -69,17 +69,17 @@ def get_some_data(params):
     pass
 
 
-def create_visualization(data):
+def create_visualization(data) -> SkillVisualization:
     # embed the data into a json layout payload
     pass
 
 
-def create_narrative(data):
+def create_narrative(data) -> str:
     # make some description of the data to appear as the narrative part of the response
     pass
 
 
-def create_chat_response_prompt(data, narrative):
+def create_chat_response_prompt(data, narrative) -> str:
     # use the data and narrative to create a prompt for the model that will generate the response
     # in the chat window
     pass
@@ -88,13 +88,22 @@ def create_chat_response_prompt(data, narrative):
 You can generate a preview for viewing with the `preview-server` by passing your skill's output to `preview_skill`:
 
 ```python
-from skill_framework import SkillInput, preview_skill
+from skill_framework import preview_skill, skill, SkillParameter
+
+@skill(
+    name="my skill",
+    parameters=[
+        SkillParameter(
+            name="metric",
+        )
+    ]
+)
+def my_skill(skill_input):
+    pass
 
 if __name__ == '__main__':
-    mock_params = SkillInput(
-        # mock values here
-    )
-    output = your_skill(mock_params)
+    mock_input = my_skill.create_input(arguments={'metric': 'sales'})
+    output = my_skill(mock_input)
     # this utility function will write the output to where the local preview server expects it
-    preview_skill(your_skill, output)
+    preview_skill(my_skill, output)
 ```

--- a/skill_framework/__init__.py
+++ b/skill_framework/__init__.py
@@ -7,10 +7,11 @@ __all__ = [
     'ExitFromSkillException',
     'ParameterDisplayDescription',
     'SuggestedQuestion',
+    'SkillVisualization'
 ]
 
 from skill_framework.skills import (skill, SkillInput, SkillParameter, SkillOutput, ExitFromSkillException,
-                                    ParameterDisplayDescription, SuggestedQuestion)
+                                    ParameterDisplayDescription, SuggestedQuestion, SkillVisualization)
 from skill_framework.preview import preview_skill
 
 __version__ = '0.2.2'

--- a/skill_framework/__init__.py
+++ b/skill_framework/__init__.py
@@ -14,4 +14,4 @@ from skill_framework.skills import (skill, SkillInput, SkillParameter, SkillOutp
                                     ParameterDisplayDescription, SuggestedQuestion, SkillVisualization)
 from skill_framework.preview import preview_skill
 
-__version__ = '0.2.2'
+__version__ = '0.3.0'

--- a/skill_framework/preview.py
+++ b/skill_framework/preview.py
@@ -1,5 +1,5 @@
-import os.path
-import datetime
+import json
+import os
 
 from skill_framework import SkillOutput
 
@@ -9,12 +9,21 @@ def preview_skill(skill, skill_output: SkillOutput):
     Writes skill template output to a file so that it can be seen by the preview app
     :param skill: the skill function
     :param skill_output: the output of the skill
-    :return:
     """
     path = f'.previews/{skill.fn.__name__}'
     if not os.path.exists(f'{path}'):
         os.makedirs(f'{path}', exist_ok=True)
     for idx, viz in enumerate(skill_output.visualizations):
         with open(f'{path}/viz-{idx}.json', 'w') as f:
-            f.write(viz.model_dump_json())
+            # this is not just calling model_dump_json so that the json embedded in the layout can be written out
+            # as json that can be read by a human, since this is for previewing outputs.
+            try:
+                viz_dict = viz.model_dump()
+                viz_dict['layout'] = json.loads(viz_dict['layout'])
+                f.write(json.dumps(viz_dict, indent=2))
+            except Exception:
+                # write it out even if invalid so the user can still review it, the preview server skips invalid layouts
+                print(f'{viz.title} contains invalid json')
+                f.write(viz.layout)
+
     print(f'Preview at localhost:8484/print/{skill.fn.__name__}')

--- a/skill_framework/preview.py
+++ b/skill_framework/preview.py
@@ -1,7 +1,7 @@
 import json
 import os
 
-from skill_framework import SkillOutput
+from skill_framework import SkillOutput, SkillVisualization
 
 
 def preview_skill(skill, skill_output: SkillOutput):
@@ -15,15 +15,19 @@ def preview_skill(skill, skill_output: SkillOutput):
         os.makedirs(f'{path}', exist_ok=True)
     for idx, viz in enumerate(skill_output.visualizations):
         with open(f'{path}/viz-{idx}.json', 'w') as f:
-            # this is not just calling model_dump_json so that the json embedded in the layout can be written out
-            # as json that can be read by a human, since this is for previewing outputs.
-            try:
-                viz_dict = viz.model_dump()
-                viz_dict['layout'] = json.loads(viz_dict['layout'])
-                f.write(json.dumps(viz_dict, indent=2))
-            except Exception:
-                # write it out even if invalid so the user can still review it, the preview server skips invalid layouts
-                print(f'{viz.title} contains invalid json')
-                f.write(viz.layout)
+            write_viz_preview(f, viz)
 
     print(f'Preview at localhost:8484/print/{skill.fn.__name__}')
+
+
+def write_viz_preview(file, viz: SkillVisualization):
+    # this is not just calling model_dump_json so that the json embedded in the layout can be written out
+    # as json that can be read by a human, since this is for previewing outputs.
+    try:
+        viz_dict = viz.model_dump()
+        viz_dict['layout'] = json.loads(viz_dict['layout'])
+        file.write(json.dumps(viz_dict, indent=2))
+    except Exception:
+        # write it out even if invalid so the user can still review it, the preview server skips invalid layouts
+        print(f'{viz.title} contains invalid json')
+        file.write(viz.layout)

--- a/skill_framework/preview.py
+++ b/skill_framework/preview.py
@@ -11,10 +11,10 @@ def preview_skill(skill, skill_output: SkillOutput):
     :param skill_output: the output of the skill
     :return:
     """
-    output_id = datetime.datetime.now().strftime('%Y-%m-%d-%H-%M-%S')
     path = f'.previews/{skill.fn.__name__}'
     if not os.path.exists(f'{path}'):
         os.makedirs(f'{path}', exist_ok=True)
-    with open(f'{path}/{output_id}.json', 'w') as f:
-        f.write(skill_output.visualization)
-        print(f'run preview-server and go to localhost:8484/print/{skill.fn.__name__}/{output_id}')
+    for idx, viz in enumerate(skill_output.visualizations):
+        with open(f'{path}/viz-{idx}.json', 'w') as f:
+            f.write(viz.model_dump_json())
+    print(f'Preview at localhost:8484/print/{skill.fn.__name__}')

--- a/skill_framework/skills.py
+++ b/skill_framework/skills.py
@@ -88,13 +88,25 @@ class SuggestedQuestion(FrameworkBaseModel):
     question: str | None = None
 
 
+class SkillVisualization(FrameworkBaseModel):
+    """
+
+    Attributes:
+        title: the title of the visualization, appears in places such as on the visualization's tab header when the
+            visualizations are tabbed
+        layout: a json-layout payload. detail on this still todo
+    """
+    title: str
+    layout: str
+
+
 class SkillOutput(FrameworkBaseModel):
     """
     Container for skill output
     Attributes:
         final_prompt: Used to prompt the model to generate the chat response
         narrative: A text element that can accompany the visualization. Markdown formatting supported.
-        visualization: A rendered json layout payload
+        visualizations: One or more SkillVisualizations, consisting of a layout describing the visualization and associated metadata
         parameter_display_descriptions: A list of ParameterDisplayDescription objects that can be used to display information
             about the actual arguments that were used by the skill. Not limited to explicit skill parameters.
         followup_questions: A list of recommended followup questions for the user to ask.
@@ -102,7 +114,7 @@ class SkillOutput(FrameworkBaseModel):
     """
     final_prompt: str | None = None
     narrative: str | None = None
-    visualization: str | None = None
+    visualizations: list[SkillVisualization] = Field(default_factory=list)
     parameter_display_descriptions: list[ParameterDisplayDescription] = Field(default_factory=list)
     followup_questions: list[SuggestedQuestion] = Field(default_factory=list)
 

--- a/test/test_preview.py
+++ b/test/test_preview.py
@@ -1,0 +1,22 @@
+import json
+from io import StringIO
+
+from skill_framework import skill, SkillVisualization
+from skill_framework.preview import write_viz_preview
+
+
+def test_preview_layout_is_json():
+    viz = SkillVisualization(title="a visualization", layout='{"test": 1}')
+    with StringIO() as file:
+        write_viz_preview(file, viz)
+        written = json.loads(file.getvalue())
+        assert written['layout']['test'] == 1, 'layout should be embedded in preview file as real json'
+
+
+def test_bad_layout_is_written():
+    bad_viz = SkillVisualization(title="bad", layout="}")
+    with StringIO() as file:
+        write_viz_preview(file, bad_viz)
+        written = file.getvalue()
+        assert written == bad_viz.layout, 'should have written layout to file even if invalid'
+

--- a/test/test_preview.py
+++ b/test/test_preview.py
@@ -1,7 +1,7 @@
 import json
 from io import StringIO
 
-from skill_framework import skill, SkillVisualization
+from skill_framework import SkillVisualization
 from skill_framework.preview import write_viz_preview
 
 


### PR DESCRIPTION
This adds support for multiple visualizations on the skill output.

- The local previewer has been updated to display each visualization in a tab
- the preview_skill utility function now just writes each visualization out to a file, and you view all the latest round of visualization by just going to a `print/<skillname>` path in the browser. No more unique timestamp per preview that makes you open a new tab
- There's now a container object for visualizations called `SkillVisualization` that can have metadata in addition to the layout, such as the title to be used by the container doing the actual rendering.

I also went through and removed some mixed usages of dataclasses vs pydantic models in favor of the latter.