### PR TITLE
add a test/preview run harness

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,7 @@ dependencies = [
     "pydantic",
     "pathspec",
     "jinja2",
+    "dotenv",
 ]
 
 [project.optional-dependencies]

--- a/readme.md
+++ b/readme.md
@@ -88,7 +88,8 @@ def create_chat_response_prompt(data, narrative) -> str:
 You can generate a preview for viewing with the `preview-server` by passing your skill's output to `preview_skill`:
 
 ```python
-from skill_framework import preview_skill, skill, SkillParameter
+from skill_framework import skill, SkillParameter
+from skill_framework.testing import SkillTestContext
 
 @skill(
     name="my skill",
@@ -102,8 +103,7 @@ def my_skill(skill_input):
     pass
 
 if __name__ == '__main__':
-    mock_input = my_skill.create_input(arguments={'metric': 'sales'})
-    output = my_skill(mock_input)
-    # this utility function will write the output to where the local preview server expects it
-    preview_skill(my_skill, output)
+    with SkillTestContext(my_skill) as ctx:
+        # this utility will write the output to where the local preview server expects it
+        ctx.preview_run({'metric': 'sales'})
 ```

--- a/skill_framework/testing.py
+++ b/skill_framework/testing.py
@@ -1,0 +1,54 @@
+import os
+from dotenv import dotenv_values
+
+from skill_framework.skills import Skill
+from skill_framework.preview import preview_skill
+
+
+class SkillTestContext:
+    """
+    This is a context manager to make it simpler to test skills locally.
+    """
+
+    def __init__(self, skill, env_values: dict | None = None, env_file: str | None = None):
+        """
+        :param skill: the @skill-annotated function that this context will wrap
+        :param env_values: values to set in the environment
+        :param env_file: file from which to load environment variables
+        """
+        self.skill: Skill = skill
+        self._initial_env = os.environ.copy()
+        self._settings = _load_settings(env_values, env_file)
+
+    def __enter__(self):
+        for k, v in self._settings.items():
+            if v:
+                os.environ[k] = v
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        os.environ = self._initial_env
+
+    def run(self, skill_args: dict):
+        skill_input = self.skill.create_input(None, skill_args)
+        return self.skill(skill_input)
+
+    def preview_run(self, skill_args: dict):
+        """
+        Runs the skill with the provided arguments and writes preview files
+        :param skill_args:
+        :return:
+        """
+        output = self.run(skill_args)
+        preview_skill(self.skill, output)
+        return output
+
+
+def _load_settings(env_values, env_file) -> dict:
+    if not env_values:
+        env_values = {}
+    if not env_file:
+        return env_values
+    env_from_file = dotenv_values(env_file)
+    return env_from_file | env_values
+

--- a/test/test.env
+++ b/test/test.env
@@ -1,0 +1,1 @@
+SOME_VALUE=value

--- a/test/test_harness.py
+++ b/test/test_harness.py
@@ -1,4 +1,4 @@
-import os.path
+import os
 
 from skill_framework.testing import SkillTestContext
 from skill_framework import skill, SkillParameter, SkillOutput
@@ -11,7 +11,6 @@ from skill_framework import skill, SkillParameter, SkillOutput
     ]
 )
 def harness_tester(skill_input):
-    import os
     some_value = os.getenv('SOME_VALUE')
     prompt = f'{some_value} - {skill_input.arguments.a}'
     return SkillOutput(final_prompt=prompt)
@@ -35,4 +34,3 @@ def test_harness_file_override():
     with SkillTestContext(harness_tester, env_values={'SOME_VALUE': 'test'}, env_file=env_path) as ctx:
         output = ctx.run({'a': 'an argument'})
     assert output.final_prompt == 'test - an argument'
-    

--- a/test/test_harness.py
+++ b/test/test_harness.py
@@ -1,0 +1,38 @@
+import os.path
+
+from skill_framework.testing import SkillTestContext
+from skill_framework import skill, SkillParameter, SkillOutput
+
+
+@skill(
+    name="test",
+    parameters=[
+        SkillParameter(name="a")
+    ]
+)
+def harness_tester(skill_input):
+    import os
+    some_value = os.getenv('SOME_VALUE')
+    prompt = f'{some_value} - {skill_input.arguments.a}'
+    return SkillOutput(final_prompt=prompt)
+
+
+def test_harness():
+    with SkillTestContext(harness_tester, {'SOME_VALUE': 'test'}) as ctx:
+        output = ctx.run({'a': 'an argument'})
+        assert output.final_prompt == 'test - an argument'
+
+
+def test_harness_file():
+    env_path = os.path.join(os.path.dirname(__file__), 'test.env')
+    with SkillTestContext(harness_tester, env_file=env_path) as ctx:
+        output = ctx.run({'a': 'an argument'})
+    assert output.final_prompt == 'value - an argument'
+
+
+def test_harness_file_override():
+    env_path = os.path.join(os.path.dirname(__file__), 'test.env')
+    with SkillTestContext(harness_tester, env_values={'SOME_VALUE': 'test'}, env_file=env_path) as ctx:
+        output = ctx.run({'a': 'an argument'})
+    assert output.final_prompt == 'test - an argument'
+    


### PR DESCRIPTION
This adds a context manager to help with testing/previewing. It can load env files (or take a dictionary of values to set in the environment) to help with configuring clients that a skill may use that can get API keys from environment variables.