### PR TITLE
adjust packaging util to always skip certain files

### DIFF
--- a/skill_framework/package.py
+++ b/skill_framework/package.py
@@ -28,11 +28,15 @@ def _package_skill(entry_file):
         print('packaging skill...')
         skill_zip.writestr('skill_config.json', json.dumps(skill_config, indent=2))
         for file in skill_files:
-            if file == f'{entry_mod_name}.zip':
+            if _always_exclude_file(file):
                 continue
             print(f'including {file}')
             skill_zip.write(file)
         print(f'created {entry_mod_name}.zip')
+
+
+def _always_exclude_file(filename: str):
+    return filename.endswith('.zip') or os.path.dirname(filename).startswith('.git')
 
 
 def _discover_files():


### PR DESCRIPTION
Adds skipping anything in `.git` for less clutter and skips nested `.zip` files to avoid issues on import. `.git` already knows to ignore its own folder, so it's very unlikely anyone has that listed in their gitignore and kinda silly to expect it.