### PR TITLE
add a utility function for resolving the path to a resource file

### DIFF
--- a/skill_framework/__init__.py
+++ b/skill_framework/__init__.py
@@ -10,11 +10,13 @@ __all__ = [
     'SkillVisualization',
     'ExportData',
     'wire_layout',
+    'skill_resource_path',
 ]
 
 from skill_framework.skills import (skill, SkillInput, SkillParameter, SkillOutput, ExitFromSkillException,
                                     ParameterDisplayDescription, SuggestedQuestion, SkillVisualization, ExportData)
 from skill_framework.preview import preview_skill
 from skill_framework.layouts import wire_layout
+from skill_framework.resources import skill_resource_path
 
 __version__ = '0.3.10'

--- a/skill_framework/resources.py
+++ b/skill_framework/resources.py
@@ -1,0 +1,9 @@
+import os
+
+
+def skill_resource_path(filename: str):
+    """
+    Helper for resolving the path of a resource file regardless of where the skill is running.
+    """
+    base_path = os.environ.get('AR_SKILL_BASE_PATH') or ''
+    return os.path.join(base_path, 'resources', filename)

--- a/skill_framework/skills.py
+++ b/skill_framework/skills.py
@@ -1,4 +1,3 @@
-import inspect
 import jinja2
 import keyword
 import os

--- a/test/test_resources.py
+++ b/test/test_resources.py
@@ -1,0 +1,13 @@
+from skill_framework import skill_resource_path
+
+
+def test_local_path():
+    path = skill_resource_path('test.txt')
+    assert path == 'resources/test.txt'
+
+
+def test_path_with_base(monkeypatch):
+    monkeypatch.setenv('AR_SKILL_BASE_PATH', 'some_base_dir')
+    path = skill_resource_path('test.txt')
+    assert path == 'some_base_dir/resources/test.txt'
+


### PR DESCRIPTION
This adds a `skill_resource_path` utility that lets us step in to prepend a base path depending on how the execution environment is making a resource available to the skill. By default (running locally with nothing special going on) it will just resolve a path to the `resources` directory.