### PR TITLE
add filepath helpers for copilot and copilot skill resources

### DIFF
--- a/skill_framework/__init__.py
+++ b/skill_framework/__init__.py
@@ -11,12 +11,14 @@ __all__ = [
     'ExportData',
     'wire_layout',
     'skill_resource_path',
+    'copilot_skill_resource_path',
+    'copilot_resource_path',
 ]
 
 from skill_framework.skills import (skill, SkillInput, SkillParameter, SkillOutput, ExitFromSkillException,
                                     ParameterDisplayDescription, SuggestedQuestion, SkillVisualization, ExportData)
 from skill_framework.preview import preview_skill
 from skill_framework.layouts import wire_layout
-from skill_framework.resources import skill_resource_path
+from skill_framework.resources import skill_resource_path, copilot_skill_resource_path, copilot_resource_path
 
 __version__ = '0.3.13'

--- a/skill_framework/resources.py
+++ b/skill_framework/resources.py
@@ -1,9 +1,30 @@
 import os
 
 
-def skill_resource_path(filename: str):
+def skill_resource_path(filename: str) -> str:
     """
     Helper for resolving the path of a resource file regardless of where the skill is running.
     """
     base_path = os.environ.get('AR_SKILL_BASE_PATH') or ''
     return os.path.join(base_path, 'resources', filename)
+
+
+def copilot_skill_resource_path(filename: str) -> str:
+    """
+    Get the path to a copilot skill resource. When running locally, this will instead look in your skill resources/
+    directory.
+    :param filename: the file name including any directories it is nested in within the resource folder
+    :return: the full path to the file for use with open() or other file reading utilities
+    """
+    resource_path = os.environ.get('AR_COPILOT_SKILL_RESOURCE_PATH')
+    return os.path.join(resource_path, filename) if resource_path else skill_resource_path(filename)
+
+
+def copilot_resource_path(filename: str) -> str:
+    """
+    Get the path to a copilot resource. When running locally, this will instead look in your skill resources/ directory.
+    :param filename: the file name including any directories it is nested in within the resource folder
+    :return: the full path to the file for use with open() or other file reading utilities
+    """
+    resource_path = os.environ.get('AR_COPILOT_RESOURCE_PATH')
+    return os.path.join(resource_path, filename) if resource_path else skill_resource_path(filename)

--- a/test/test_resources.py
+++ b/test/test_resources.py
@@ -1,4 +1,4 @@
-from skill_framework import skill_resource_path
+from skill_framework import skill_resource_path, copilot_resource_path, copilot_skill_resource_path
 
 
 def test_local_path():
@@ -11,3 +11,22 @@ def test_path_with_base(monkeypatch):
     path = skill_resource_path('test.txt')
     assert path == 'some_base_dir/resources/test.txt'
 
+
+def test_copilot_skill_resource(monkeypatch):
+    local_path = copilot_skill_resource_path('test.txt')
+    assert local_path == 'resources/test.txt'
+    monkeypatch.setenv('AR_COPILOT_SKILL_RESOURCE_PATH', 'some_base_dir')
+    path = copilot_skill_resource_path('test.txt')
+    assert path == 'some_base_dir/test.txt'
+    nested_path = copilot_skill_resource_path('dir/test.txt')
+    assert nested_path == 'some_base_dir/dir/test.txt'
+
+
+def test_copilot_resource(monkeypatch):
+    local_path = copilot_resource_path('test.txt')
+    assert local_path == 'resources/test.txt'
+    monkeypatch.setenv('AR_COPILOT_RESOURCE_PATH', 'some_base_dir')
+    path = copilot_resource_path('test.txt')
+    assert path == 'some_base_dir/test.txt'
+    nested_path = copilot_resource_path('dir/test.txt')
+    assert nested_path == 'some_base_dir/dir/test.txt'


### PR DESCRIPTION
This adds helpers for resolving filepaths to uploaded copilot/copilot skill resources. If the environment variables that get set in the exec environment aren't defined these methods will fall back to looking in the local `resources/` directory.