### PR TITLE
Add request_source to SkillInput

### DIFF
--- a/skill_framework/__init__.py
+++ b/skill_framework/__init__.py
@@ -1,6 +1,7 @@
 __all__ = [
     'skill',
     'SkillInput',
+    'RequestSource',
     'SkillParameter',
     'preview_skill',
     'SkillOutput',
@@ -37,7 +38,8 @@ from skill_framework.pipelines import (BasePipeline, PipelineOutput, PipelineReq
                                        AnswerEngineOutputTools, AnswerEngineLlmTools, ModelExecutionOptions,
                                        ModelExecutionTarget)
 from skill_framework.skills import (skill, SkillInput, SkillParameter, SkillOutput, ExitFromSkillException,
-                                    ParameterDisplayDescription, SuggestedQuestion, SkillVisualization, ExportData)
+                                    ParameterDisplayDescription, SuggestedQuestion, SkillVisualization, ExportData,
+                                    RequestSource)
 from skill_framework.preview import preview_skill
 from skill_framework.layouts import wire_layout
 from skill_framework.resources import skill_resource_path, copilot_skill_resource_path, copilot_resource_path

--- a/skill_framework/skills.py
+++ b/skill_framework/skills.py
@@ -57,11 +57,13 @@ class SkillInput:
             generated dataclass at runtime, so you can use attribute-style access to refer to them. "empty" values will
             be populated based on your declared parameters. f. ex, a list parameter for which no arguments were captured
             will be initialized to an empty list.
+        request_source: where the request originated, e.g. "WEB" or "MOBILE"; skills may branch on it. Defaults to "WEB".
     """
 
-    def __init__(self, assistant_id, arguments):
+    def __init__(self, assistant_id, arguments, request_source="WEB"):
         self.assistant_id = assistant_id
         self.arguments = arguments
+        self.request_source = request_source
 
     def __str__(self):
         return str(self.__dict__)
@@ -171,11 +173,11 @@ class Skill:
     def __call__(self, *args, **kwargs):
         return self.fn(*args, **kwargs)
 
-    def create_input(self, assistant_id=None, arguments: dict | None = None) -> SkillInput:
+    def create_input(self, assistant_id=None, arguments: dict | None = None, request_source: str = "WEB") -> SkillInput:
         if not arguments:
             arguments = {}
         skill_arguments = _create_skill_arguments(self, arguments)
-        return SkillInput(assistant_id=assistant_id, arguments=skill_arguments)
+        return SkillInput(assistant_id=assistant_id, arguments=skill_arguments, request_source=request_source)
 
 
 def _create_skill_arguments(skill: Skill, arguments):

--- a/skill_framework/skills.py
+++ b/skill_framework/skills.py
@@ -1,6 +1,7 @@
 import jinja2
 import keyword
 import os
+from enum import Enum
 from pydantic import BaseModel, ConfigDict, field_validator, Field, create_model
 from typing import Callable, Literal, Any
 
@@ -46,6 +47,21 @@ def is_valid_parameter_name(name: str) -> bool:
     return name.isidentifier() and not keyword.iskeyword(name)
 
 
+class RequestSource(Enum):
+    """Where a skill request originated."""
+    WEB = "WEB"
+    MOBILE = "MOBILE"
+
+    @classmethod
+    def _missing_(cls, value):
+        # Lenient: case-insensitive match; unknown/unset sources fall back to WEB (forward-compatible).
+        if isinstance(value, str):
+            for member in cls:
+                if member.value == value.upper():
+                    return member
+        return cls.WEB
+
+
 class SkillInput:
     """
     Container for context and parameter arguments passed into the skill. Recommended to create this object with
@@ -57,13 +73,13 @@ class SkillInput:
             generated dataclass at runtime, so you can use attribute-style access to refer to them. "empty" values will
             be populated based on your declared parameters. f. ex, a list parameter for which no arguments were captured
             will be initialized to an empty list.
-        request_source: where the request originated, e.g. "WEB" or "MOBILE"; skills may branch on it. Defaults to "WEB".
+        request_source: a RequestSource (WEB or MOBILE) for where the request originated; a string is coerced. Defaults to WEB.
     """
 
-    def __init__(self, assistant_id, arguments, request_source="WEB"):
+    def __init__(self, assistant_id, arguments, request_source=RequestSource.WEB):
         self.assistant_id = assistant_id
         self.arguments = arguments
-        self.request_source = request_source
+        self.request_source = RequestSource(request_source)
 
     def __str__(self):
         return str(self.__dict__)
@@ -173,7 +189,7 @@ class Skill:
     def __call__(self, *args, **kwargs):
         return self.fn(*args, **kwargs)
 
-    def create_input(self, assistant_id=None, arguments: dict | None = None, request_source: str = "WEB") -> SkillInput:
+    def create_input(self, assistant_id=None, arguments: dict | None = None, request_source: str | RequestSource = RequestSource.WEB) -> SkillInput:
         if not arguments:
             arguments = {}
         skill_arguments = _create_skill_arguments(self, arguments)

--- a/skill_framework/testing.py
+++ b/skill_framework/testing.py
@@ -29,17 +29,17 @@ class SkillTestContext:
     def __exit__(self, exc_type, exc_val, exc_tb):
         os.environ = self._initial_env
 
-    def run(self, skill_args: dict):
-        skill_input = self.skill.create_input(None, skill_args)
+    def run(self, skill_args: dict, request_source: str = "WEB"):
+        skill_input = self.skill.create_input(None, skill_args, request_source=request_source)
         return self.skill(skill_input)
 
-    def preview_run(self, skill_args: dict):
+    def preview_run(self, skill_args: dict, request_source: str = "WEB"):
         """
         Runs the skill with the provided arguments and writes preview files
         :param skill_args:
         :return:
         """
-        output = self.run(skill_args)
+        output = self.run(skill_args, request_source=request_source)
         preview_skill(self.skill, output)
         return output
 

--- a/test/test_input_init.py
+++ b/test/test_input_init.py
@@ -1,4 +1,4 @@
-from skill_framework import skill, SkillParameter, SkillInput
+from skill_framework import skill, SkillParameter, SkillInput, RequestSource
 
 @skill(
     name="some_skill",
@@ -34,12 +34,27 @@ def test_invalid_arg():
 
 def test_request_source_defaults_web():
     skill_input = dummy_skill.create_input(arguments={'metrics': ['sales']})
-    assert skill_input.request_source == 'WEB'
+    assert skill_input.request_source is RequestSource.WEB
 
 
-def test_request_source_passthrough():
+def test_request_source_parses_string_to_enum():
     skill_input = dummy_skill.create_input(arguments={'metrics': ['sales']}, request_source='MOBILE')
-    assert skill_input.request_source == 'MOBILE'
+    assert skill_input.request_source is RequestSource.MOBILE
+
+
+def test_request_source_accepts_enum():
+    skill_input = dummy_skill.create_input(arguments={'metrics': ['sales']}, request_source=RequestSource.MOBILE)
+    assert skill_input.request_source is RequestSource.MOBILE
+
+
+def test_request_source_is_case_insensitive():
+    skill_input = dummy_skill.create_input(arguments={'metrics': ['sales']}, request_source='mobile')
+    assert skill_input.request_source is RequestSource.MOBILE
+
+
+def test_request_source_unknown_falls_back_to_web():
+    skill_input = dummy_skill.create_input(arguments={'metrics': ['sales']}, request_source='future_source')
+    assert skill_input.request_source is RequestSource.WEB
 
 
 def test_request_source_is_not_a_declared_argument():

--- a/test/test_input_init.py
+++ b/test/test_input_init.py
@@ -32,3 +32,19 @@ def test_invalid_arg():
     assert not hasattr(skill_input.arguments, 'bad_arg')
 
 
+def test_request_source_defaults_web():
+    skill_input = dummy_skill.create_input(arguments={'metrics': ['sales']})
+    assert skill_input.request_source == 'WEB'
+
+
+def test_request_source_passthrough():
+    skill_input = dummy_skill.create_input(arguments={'metrics': ['sales']}, request_source='MOBILE')
+    assert skill_input.request_source == 'MOBILE'
+
+
+def test_request_source_is_not_a_declared_argument():
+    # request_source is request context surfaced on SkillInput, never a declared skill parameter
+    skill_input = dummy_skill.create_input(arguments={'metrics': ['sales']}, request_source='MOBILE')
+    assert not hasattr(skill_input.arguments, 'request_source')
+
+


### PR DESCRIPTION
Adds a request source to skill inputs so skills can tell where a request originated (e.g. web vs mobile) so they can adapt their behavior.