### PR TITLE
Hotfix: Add alt_visualizations to SkillOutput

### DIFF
--- a/layout-previewer/package-lock.json
+++ b/layout-previewer/package-lock.json
@@ -46,7 +46,7 @@
     },
     "node_modules/@answerrocket/dynamic-layout": {
       "version": "0.1.0",
-      "resolved": "git+ssh://git@bitbucket.org/aglabs/dynamic-layout.git#4eb636c407cf76d734a038183d1bebdeba78b627",
+      "resolved": "git+ssh://git@bitbucket.org/aglabs/dynamic-layout.git#f943eab5291328fb34356839b18d5393fb8b64cb",
       "hasInstallScript": true,
       "license": "UNLICENSED",
       "dependencies": {

--- a/skill_framework/__init__.py
+++ b/skill_framework/__init__.py
@@ -21,4 +21,4 @@ from skill_framework.preview import preview_skill
 from skill_framework.layouts import wire_layout
 from skill_framework.resources import skill_resource_path, copilot_skill_resource_path, copilot_resource_path
 
-__version__ = '0.3.16'
+__version__ = '0.3.16.1'

--- a/skill_framework/__init__.py
+++ b/skill_framework/__init__.py
@@ -21,4 +21,4 @@ from skill_framework.preview import preview_skill
 from skill_framework.layouts import wire_layout
 from skill_framework.resources import skill_resource_path, copilot_skill_resource_path, copilot_resource_path
 
-__version__ = '0.3.16.1'
+__version__ = '0.3.16.2'

--- a/skill_framework/skills.py
+++ b/skill_framework/skills.py
@@ -129,6 +129,7 @@ class SkillOutput(FrameworkBaseModel):
         final_prompt: Used to prompt the model to generate the chat response
         narrative: A text element that can accompany the visualization. Markdown formatting supported.
         visualizations: One or more SkillVisualizations, consisting of a layout describing the visualization and associated metadata
+        alt_visualizations: Alternate SkillVisualizations delivered to the external API alongside visualizations. Not rendered by the Max web app.
         ppt_slides: One or more layout json strings, consisting of a layout describing the visualization and associated metadata for ppt export
         parameter_display_descriptions: A list of ParameterDisplayDescription objects that can be used to display information
             about the actual arguments that were used by the skill. Not limited to explicit skill parameters.
@@ -139,6 +140,7 @@ class SkillOutput(FrameworkBaseModel):
     final_prompt: str | None = None
     narrative: str | None = None
     visualizations: list[SkillVisualization] = Field(default_factory=list)
+    alt_visualizations: list[SkillVisualization] = Field(default_factory=list)
     ppt_slides: list[str] = Field(default_factory=list)
     pdfs: list[str] = Field(default_factory=list)
     parameter_display_descriptions: list[ParameterDisplayDescription] = Field(default_factory=list)


### PR DESCRIPTION
Lets skills return an alternate set of visualizations, e.g. mobile-formatted, alongside their standard visualizations.